### PR TITLE
Fixed incorrect doc updating on save()

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -79,7 +79,15 @@
         if (err) {
           return callback(err);
         }
+
+        //  Undo the effects of savePrep as data object is the only one
+        //  that the JugglingDb model can access.
+        helpers.undoPrep(data);
+        //  Update the data object with the revision returned by CouchDb.
         data._rev = doc.rev;
+
+        //  This callback makes no sense in the context of JugglingDb invocation
+        //  but I'm leaving it as-is for other possible use cases.
         return callback(null, doc.id, doc.rev);
       });
     };
@@ -350,6 +358,13 @@
       if (data._rev === null) {
         return delete data._rev;
       }
+    },
+    undoPrep: function(data) {
+      var _id;
+      if (_id = data._id) {
+        data.id = _id.toString();
+      }
+      delete data._id;
     }
   };
 


### PR DESCRIPTION
`savePrep` removes `id` and replaces it with `_id`. However, this has to be reverted before returning so that JugglingDb can continue using `id` its expecting.
