### PR TITLE
Fixed filtering in all

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -33,7 +33,7 @@
         }
       }
     };
-    return db.insert(design, '_design/nano', callback);
+    return helpers.updateDesign(db, '_design/nano', design, callback);
   };
 
   NanoAdapter = (function() {
@@ -59,10 +59,31 @@
     }
 
     NanoAdapter.prototype.define = function(descr) {
+      var design, designName, hasIndexes, modelName, propName, value, viewName, _ref;
       descr.properties._rev = {
         type: String
       };
-      return this._models[descr.model.modelName] = descr;
+      modelName = descr.model.modelName;
+      design = {
+        views: {}
+      };
+      hasIndexes = false;
+      _ref = descr.properties;
+      for (propName in _ref) {
+        value = _ref[propName];
+        if (value.index) {
+          hasIndexes = true;
+          viewName = helpers.viewName(propName);
+          design.views[viewName] = {
+            map: 'function (doc) { if (doc.model === \'' + modelName + '\') return emit(doc.' + propName + ', null); }'
+          };
+        }
+      }
+      if (hasIndexes) {
+        designName = '_design/' + helpers.designName(modelName);
+        helpers.updateDesign(this.db, designName, design);
+      }
+      return this._models[modelName] = descr;
     };
 
     NanoAdapter.prototype.create = function() {
@@ -226,14 +247,35 @@
     };
 
     NanoAdapter.prototype.all = function(model, filter, callback) {
-      var params,
+      var designName, params, propName, props, value, viewName, where,
         _this = this;
       params = {
         keys: [this.table(model)],
         include_docs: true
       };
-      return this.db.view('nano', 'by_model', params, function(err, body) {
-        var doc, docs, i, k, key, orders, row, sorting, v, where, _i, _len;
+      if (filter.offset) {
+        params.skip = filter.offset;
+      }
+      if (filter.limit) {
+        params.limit = filter.limit;
+      }
+      designName = 'nano';
+      viewName = 'by_model';
+      if (where = filter != null ? filter.where : void 0) {
+        props = this._models[model].properties;
+        for (propName in where) {
+          value = where[propName];
+          if (value && (props[propName] != null) && props[propName].index) {
+            designName = helpers.designName(model);
+            viewName = helpers.viewName(propName);
+            params.key = _.isDate(value) ? value.getTime() : value;
+            delete params.keys;
+            break;
+          }
+        }
+      }
+      return this.db.view(designName, viewName, params, function(err, body) {
+        var doc, docs, i, k, key, orders, row, sorting, v, _i, _len;
         if (err) {
           return callback(err);
         }
@@ -358,6 +400,40 @@
         data.id = _id.toString();
       }
       delete data._id;
+    },
+    designName: function(modelName) {
+      return 'nano-' + modelName;
+    },
+    viewName: function(propName) {
+      return 'by_' + propName;
+    },
+    invokeCallbackOrLogError: function(callback, err, res) {
+      if (callback) {
+        return callback(err, res);
+      } else if (err) {
+        return console.log(err);
+      }
+    },
+    updateDesign: function(db, designName, design, callback) {
+      var _this = this;
+      return db.get(designName, function(err, designDoc) {
+        if (err && err.error !== 'not_found') {
+          helpers.invokeCallbackOrLogError(callback, err, designDoc);
+          return;
+        }
+        if (!designDoc) {
+          designDoc = design;
+        } else {
+          if (_.isEqual(designDoc.views, design.views)) {
+            helpers.invokeCallbackOrLogError(callback, null, designDoc);
+            return;
+          }
+          designDoc.views = design.views;
+        }
+        return db.insert(designDoc, designName, function(err, insertedDoc) {
+          return helpers.invokeCallbackOrLogError(callback, err, insertedDoc);
+        });
+      });
     }
   };
 


### PR DESCRIPTION
This is a major patch. I have added automatic generation of CouchDb design documents for all models that have indexed properties. For all such models a separate design document is created and for each indexed property a separate view is created with key being the values of the property.

For example if we had a `User` model with indexed `username` property:

``` javascript
var User = describe('User', function () {
    property('username', String, { index: true });
....
});
```

This would then automatically generate `_design/nano-User` design document with `by_username` view who's `map` is defined as:

```
function(doc) { if (doc.model === 'User') return emit(doc.username, null); }
```

These views are then used in `Adapter.all()` for indexed search if any indexed property is in the `where` param.

I've also added `skip` (read from `offset`) and `limit` to nano parameters. `Model.iterate()` was falling into infinite loop due to the lack of these params.
