### PR TITLE
Updated insert callback in save function

### DIFF
--- a/lib/nano.js
+++ b/lib/nano.js
@@ -102,7 +102,7 @@
         }
         helpers.undoPrep(data);
         data._rev = doc.rev;
-        return callback(null, doc.id, doc.rev);
+        return callback(null, doc.id, doc);
       });
     };
 

--- a/src/nano.coffee
+++ b/src/nano.coffee
@@ -61,7 +61,7 @@ class NanoAdapter
       data._rev = doc.rev
       # This callback makes no sense in the context of JugglingDb invocation
       # but I'm leaving it as-is for other possible use cases.
-      callback null, doc.id, doc.rev #doc.id, doc.rev
+      callback null, doc.id, doc #doc.id, doc.rev
 
   updateOrCreate: (model, data = {}, callback) =>
     @exists model, data.id, (err, exists) =>


### PR DESCRIPTION
jugglingDB expects a doc with _rev key, otherwise there is a TypeError: Object.keys called on non-object
when the object is saved to the database
